### PR TITLE
Some small fixes

### DIFF
--- a/ComplexProperties/TimeZones/TimeZoneTransitionGroup.cs
+++ b/ComplexProperties/TimeZones/TimeZoneTransitionGroup.cs
@@ -130,7 +130,7 @@ namespace Microsoft.Exchange.WebServices.Data
                     adjustmentRule.DateStart.Year);
                 standardPeriodToSet.Name = standardPeriod.Name;
                 standardPeriodToSet.Bias = standardPeriod.Bias;
-                this.timeZoneDefinition.Periods.Add(standardPeriodToSet.Id, standardPeriodToSet);
+                this.timeZoneDefinition.Periods.AddOrUpdate(standardPeriodToSet.Id, standardPeriodToSet);
 
                 this.transitionToStandard = new TimeZoneTransition(this.timeZoneDefinition, standardPeriodToSet);
                 this.transitions.Add(this.transitionToStandard);
@@ -147,7 +147,7 @@ namespace Microsoft.Exchange.WebServices.Data
                 daylightPeriod.Name = TimeZonePeriod.DaylightPeriodName;
                 daylightPeriod.Bias = standardPeriod.Bias - adjustmentRule.DaylightDelta;
 
-                this.timeZoneDefinition.Periods.Add(daylightPeriod.Id, daylightPeriod);
+                this.timeZoneDefinition.Periods.AddOrUpdate(daylightPeriod.Id, daylightPeriod);
 
                 this.transitionToDaylight = TimeZoneTransition.CreateTimeZoneTransition(
                     this.timeZoneDefinition,
@@ -161,7 +161,7 @@ namespace Microsoft.Exchange.WebServices.Data
                     adjustmentRule.DateStart.Year);
                 standardPeriodToSet.Name = standardPeriod.Name;
                 standardPeriodToSet.Bias = standardPeriod.Bias;
-                this.timeZoneDefinition.Periods.Add(standardPeriodToSet.Id, standardPeriodToSet);
+                this.timeZoneDefinition.Periods.AddOrUpdate(standardPeriodToSet.Id, standardPeriodToSet);
 
                 this.transitionToStandard = TimeZoneTransition.CreateTimeZoneTransition(
                     this.timeZoneDefinition,

--- a/Core/EwsHttpWebRequest.cs
+++ b/Core/EwsHttpWebRequest.cs
@@ -89,8 +89,10 @@ namespace Microsoft.Exchange.WebServices.Data
         {
             var message = new HttpRequestMessage(new HttpMethod(Method), RequestUri);
             message.Content = new StringContent(Content);
-            //if (!string.IsNullOrEmpty(ContentType))
-            //    message.Content.Headers.ContentType = new MediaTypeHeaderValue(ContentType);
+            if (!string.IsNullOrEmpty(ContentType)) {
+              message.Content.Headers.ContentType = null;
+              message.Content.Headers.TryAddWithoutValidation("Content-Type", ContentType);
+            }
 
             if (!string.IsNullOrEmpty(UserAgent))
             {

--- a/Extensions/DictionaryExtensions.cs
+++ b/Extensions/DictionaryExtensions.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+
+namespace Microsoft.Exchange.WebServices {
+  public static class DictionaryExtensions {
+    public static void AddOrUpdate<T1,T2>(this Dictionary<T1,T2> dic,T1 key,T2 value){
+      if(dic.ContainsKey(key))
+        dic[key] = value;
+      else
+        dic.Add(key, value);
+    }
+  }
+
+}


### PR DESCRIPTION
This PR will fix 2 small issues:

- TimeZone issue described in #16 
- Not sending the correct headers #32 

For the TimeZones I created a small extension so that it doesn't disturb anything, but it doesn't crash on Ubuntu because of adding duplicate TimeZoneId's

You commented out the sending of the headers with the HttpClient, probably because of that they didn't validate in the `MediaTypeHeaderValue`. I changed it to just send the Content-Type anyway.