### PR TITLE
Non hanging subscriptions and timezonetransitionlists

### DIFF
--- a/ComplexProperties/TimeZones/TimeZoneTransitionGroup.cs
+++ b/ComplexProperties/TimeZones/TimeZoneTransitionGroup.cs
@@ -127,7 +127,7 @@ namespace Microsoft.Exchange.WebServices.Data
                 standardPeriodToSet.Id = string.Format(
                     "{0}/{1}",
                     standardPeriod.Id,
-                    adjustmentRule.DateStart.Year);
+                    adjustmentRule.DateSTart.ToString("yyyyMMdd"));
                 standardPeriodToSet.Name = standardPeriod.Name;
                 standardPeriodToSet.Bias = standardPeriod.Bias;
                 this.timeZoneDefinition.Periods.Add(standardPeriodToSet.Id, standardPeriodToSet);
@@ -143,7 +143,7 @@ namespace Microsoft.Exchange.WebServices.Data
                 daylightPeriod.Id = string.Format(
                     "{0}/{1}",
                     TimeZonePeriod.DaylightPeriodId,
-                    adjustmentRule.DateStart.Year);
+                    adjustmentRule.DateSTart.ToString("yyyyMMdd"));
                 daylightPeriod.Name = TimeZonePeriod.DaylightPeriodName;
                 daylightPeriod.Bias = standardPeriod.Bias - adjustmentRule.DaylightDelta;
 
@@ -158,7 +158,7 @@ namespace Microsoft.Exchange.WebServices.Data
                 standardPeriodToSet.Id = string.Format(
                     "{0}/{1}",
                     standardPeriod.Id,
-                    adjustmentRule.DateStart.Year);
+                    adjustmentRule.DateSTart.ToString("yyyyMMdd"));
                 standardPeriodToSet.Name = standardPeriod.Name;
                 standardPeriodToSet.Bias = standardPeriod.Bias;
                 this.timeZoneDefinition.Periods.Add(standardPeriodToSet.Id, standardPeriodToSet);

--- a/Core/EwsHttpWebRequest.cs
+++ b/Core/EwsHttpWebRequest.cs
@@ -107,7 +107,7 @@ namespace Microsoft.Exchange.WebServices.Data
             HttpResponseMessage response = null;
             try
             {
-                response = await _httpClient.SendAsync(message, token);
+                response = await _httpClient.SendAsync(message, HttpCompletionOption.ResponseHeadersRead., token);
             }
             catch(Exception exception)
             {


### PR DESCRIPTION
Made two alterations to get the nuget to avoid hanging requests when subscribing to exchange notifications and also to avoid crasches due to different timezone-handling on linux/windows.

I have not tested the changes extensively and am not sure if they have effects outside of the scope that I use in my project.