### PR TITLE
Handling empty Content-Encoding header

### DIFF
--- a/Core/Requests/ServiceRequestBase.cs
+++ b/Core/Requests/ServiceRequestBase.cs
@@ -112,6 +112,11 @@ namespace Microsoft.Exchange.WebServices.Data
 
         private static Stream WrapStream(Stream responseStream, string contentEncoding)
         {
+            if (string.IsNullOrEmpty(contentEncoding))
+            {
+                return responseStream;
+            }
+
             if (contentEncoding.ToLowerInvariant().Contains("gzip"))
             {
                 return new GZipStream(responseStream, CompressionMode.Decompress);


### PR DESCRIPTION
A fix for the bug [reported](https://github.com/OfficeDev/ews-managed-api/issues/217) in the original repository, which later was also [resolved](https://github.com/OfficeDev/ews-managed-api/pull/248/files) there but never got merged to the actual project.