### PR TITLE
Fix incorrect use of AuthenticationHeaderValue

### DIFF
--- a/Credentials/OAuthCredentials.cs
+++ b/Credentials/OAuthCredentials.cs
@@ -96,7 +96,7 @@ namespace Microsoft.Exchange.WebServices.Data
                 }
             }
 
-            this.token = BearerAuthenticationType + " " + rawToken;
+            this.token = rawToken;
         }
 
         /// <summary>
@@ -122,7 +122,7 @@ namespace Microsoft.Exchange.WebServices.Data
             if (this.token != null)
             {
                 request.Headers.Remove(HttpRequestHeader.Authorization.ToString());
-                request.Headers.Authorization = new AuthenticationHeaderValue(this.token);
+                request.Headers.Authorization = new AuthenticationHeaderValue(BearerAuthenticationType, this.token);
             }
             else
             {


### PR DESCRIPTION
The constructor with a single string corresponds to the scheme
(and therefore currently fails with a FormatException).
The token should be passed with the two-parameters constructor.