### PR TITLE
Adding Visual Studio .vs/ folder exclusion and update README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -184,3 +184,6 @@ UpgradeLog*.htm
 FakesAssemblies/
 /project.lock.json
 /.svn
+
+# Visual Studio local files
+.vs/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Quick introduction
 
-This is a NET Standard 1.4 port of EWS API. Here are some tips to take into account.
+This is a NET Standard 2.0 port of EWS API. Here are some tips to take into account.
 
 - NET Framework version is as functional as original
 - Almost all functions involving HTTP requests are now async


### PR DESCRIPTION
Just two small changes to make live easier:
* The  .vs/ folder was missing in the .gitignore 
* The README still mentioned netstandard1.4 but the library is targeting netstandard2.0