### PR TITLE
Update package references to address vulnerabilities including transitive packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -184,3 +184,6 @@ UpgradeLog*.htm
 FakesAssemblies/
 /project.lock.json
 /.svn
+
+# Visual Studio cache/options directory
+.vs/

--- a/Microsoft.Exchange.WebServices.NETStandard.csproj
+++ b/Microsoft.Exchange.WebServices.NETStandard.csproj
@@ -26,7 +26,7 @@ restored ldap autodiscover functionality
 merged changes from official Microsoft repository
 added cancellation token for most of methods
     </PackageReleaseNotes>
-    <Version>2.0.0-beta2</Version>
+    <Version>2.0.0-beta4</Version>
     <PackageLicenseFile>license.txt</PackageLicenseFile>
   </PropertyGroup>
 
@@ -39,7 +39,7 @@ added cancellation token for most of methods
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.Security.Cryptography.Xml">
-      <Version>4.7.0</Version>
+      <Version>4.7.1</Version>
     </PackageReference>
   </ItemGroup>
 
@@ -49,7 +49,8 @@ added cancellation token for most of methods
 
   <ItemGroup>
     <PackageReference Include="System.DirectoryServices" Version="4.7.0" />
-    <PackageReference Include="System.Net.Http" Version="4.3.3" />
+    <PackageReference Include="System.Drawing.Common" Version="4.7.3" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This is an update to address vulnerability warnings on transitive packages, which are now reported in builds if you have the lasted Visual Studio 2022 (or Build Tools), or .NET 9 SDK even if targeting an earlier version.

* `System.Drawing.Common` is a child dependency for some reason and this has a critical vulnerability in version 4.7.0 - updated to 4.7.3
* `System.Net.Http` has a high vulnerability in version 4.3.3 - updated to 4.3.4
* `System.Security.Cryptography.Xml` has a moderate vulnerability in version 4.7.0 - updated to 4.7.1

Only updated to highest patch version that isn't vulnerable to avoid potential breaking changes.

I don't know if there's any activity here however but have made these changes on a local copy and using a local folder repo to use it. Pushed build to 2.0.0-beta4 as it's next version after the official package in nuget. Noting csproj in the repository still refers to 2.0.0-beta2 yet beta3 was published.

This would also include https://github.com/sherlock1982/ews-managed-api/pull/33 if published, as the merge date is later than beta3 publish date in nuget?

I realise EWS is deprecated, but we still have to support it for on-prem Exchange server customers and Microsoft have abandoned us.